### PR TITLE
Added Descriptions to Carousel Items

### DIFF
--- a/src/components/CarouselComponent.js
+++ b/src/components/CarouselComponent.js
@@ -10,18 +10,18 @@ import {
 const items = [
   {
     src: "/assets/images/classic-beef-stroganoff.png",
-    altText: "Slide 1",
-    caption: "Slide 1"
+    altText: "Classic Beef Stroganoff",
+    caption: "Very Delicous!"
   },
   {
     src: "/assets/images/strawberry-chocolate-mousse-cake.png",
-    altText: "Slide 2",
-    caption: "Slide 2"
+    altText: "Strawberry Chocolate Mousse cake",
+    caption: "Tasty Delights!"
   },
   {
     src: "/assets/images/fluffy-pancakes.png",
-    altText: "Slide 3",
-    caption: "Slide 3"
+    altText: "Fluffy Pancakes",
+    caption: "Syrupy Goodness!"
   }
 ];
 


### PR DESCRIPTION
Added Descriptions to Carousel Items. Now, the slide isn't saying "Slide One, Slide Two." Placeholders removed and given actual descriptions. 